### PR TITLE
StateInfo should be shown to be used in hereNow()

### DIFF
--- a/lib/pubnub.dart
+++ b/lib/pubnub.dart
@@ -9,7 +9,7 @@ export './src/dx/channel/channel.dart' show Channel;
 export './src/dx/channel/channel_group.dart' show ChannelGroup;
 
 export './src/dx/_endpoints/publish.dart' show PublishResult;
-export './src/dx/_endpoints/presence.dart' show HeartbeatResult, LeaveResult;
+export './src/dx/_endpoints/presence.dart' show HeartbeatResult, LeaveResult, StateInfo;
 export './src/dx/_endpoints/signal.dart' show SignalResult;
 
 export './src/dx/subscribe/subscription.dart' show Subscription;


### PR DESCRIPTION
StateInfo is used as a parameter to pubnub.hereNow() function. However, StateInfo is hidden from the user. With this, we can call hereNow() with a StateInfo that we choose.