### PR TITLE
Fix readme git package usage

### DIFF
--- a/pubnub/README.md
+++ b/pubnub/README.md
@@ -26,7 +26,9 @@ If you want to use the latest, unreleased version of `pubnub`, you can add it to
 ```yaml
 dependencies:
   pubnub:
-    git: git://github.com/pubnub/dart.git
+    git:
+      url: git://github.com/pubnub/dart.git
+      path: pubnub
 ```
 
 ### Using a local copy of the repository

--- a/pubnub/README.md
+++ b/pubnub/README.md
@@ -27,7 +27,7 @@ If you want to use the latest, unreleased version of `pubnub`, you can add it to
 dependencies:
   pubnub:
     git:
-      url: git://github.com/pubnub/dart.git
+      url: https://github.com/pubnub/dart
       path: pubnub
 ```
 


### PR DESCRIPTION
Hello and thank you for your work! 

When I follow the instructions in the README on adding the dependency as a Git package, I get the following error:  

```sh
Resolving dependencies...
Could not find a file named "pubspec.yaml" in git://github.com/pubnub/dart.git 01a375fc5f1ad744fbd3df92aa9c8b6d5ab74fed.
pub finished with exit code 1
```

I have updated the README with what I believe is the correct usage in this case.

Thanks! 