### PR TITLE
fix: prevent the SDK from adding forbidden headers to requests

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,5 +1,12 @@
 ---
 changelog:
+  - date: 2022-04-06
+    version: v4.1.2
+    changes:
+      - type: bug
+        text: "Adds a fix that prevents the SDK from adding forbidden headers in browser environments."
+      - type: bug
+        text: "Fixes getFileUrl method by adding uuid in query parameters."
   - date: 2022-04-04
     version: v4.1.1
     changes:
@@ -381,7 +388,7 @@ supported-platforms:
     platforms:
       - "Dart SDK >=2.6.0 <3.0.0"
     version: "PubNub Dart SDK"
-version: "4.1.1"
+version: "4.1.2"
 sdks:
   -
     full-name: PubNub Dart SDK

--- a/pubnub/CHANGELOG.md
+++ b/pubnub/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v4.1.2
+April 06 2022
+
+#### Fixed
+- Adds a fix that prevents the SDK from adding forbidden headers in browser environments.
+- Fixes getFileUrl method by adding uuid in query parameters.
+
 ## v4.1.1
 April 04 2022
 

--- a/pubnub/README.md
+++ b/pubnub/README.md
@@ -14,7 +14,7 @@ To add the package to your Dart or Flutter project, add `pubnub` as a dependency
 
 ```yaml
 dependencies:
-  pubnub: ^4.1.1
+  pubnub: ^4.1.2
 ```
 
 After adding the dependency to `pubspec.yaml`, run the `pub get` command in the root directory of your project (the same that the `pubspec.yaml` is in).

--- a/pubnub/lib/src/core/core.dart
+++ b/pubnub/lib/src/core/core.dart
@@ -21,7 +21,7 @@ class Core {
   /// Internal module responsible for supervising.
   SupervisorModule supervisor = SupervisorModule();
 
-  static String version = '4.1.1';
+  static String version = '4.1.2';
 
   Core(
       {Keyset? defaultKeyset,

--- a/pubnub/lib/src/dx/files/files.dart
+++ b/pubnub/lib/src/dx/files/files.dart
@@ -255,6 +255,7 @@ class FileDx {
     ];
     var queryParams = {
       'pnsdk': 'PubNub-Dart/${Core.version}',
+      'uuid': keyset.uuid.value,
       if (keyset.secretKey != null)
         'timestamp': '${Time().now()!.millisecondsSinceEpoch ~/ 1000}',
       if (keyset.authKey != null) 'auth': keyset.authKey!

--- a/pubnub/lib/src/networking/request_handler/html.dart
+++ b/pubnub/lib/src/networking/request_handler/html.dart
@@ -8,6 +8,7 @@ import 'package:pool/pool.dart';
 import 'package:pubnub/core.dart';
 
 import '../response/response.dart';
+import '../utils.dart';
 
 final _logger = injectLogger('pubnub.networking.request_handler');
 
@@ -107,7 +108,10 @@ class RequestHandler extends IRequestHandler {
       });
 
       for (var header in headers.entries) {
-        request.setRequestHeader(header.key, header.value);
+        // NOTE: See https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name
+        if (!isHeaderForbidden(header.key)) {
+          request.setRequestHeader(header.key, header.value);
+        }
       }
 
       _logger.info('($_id) Starting request to "$uri"...');

--- a/pubnub/lib/src/networking/utils.dart
+++ b/pubnub/lib/src/networking/utils.dart
@@ -24,5 +24,6 @@ const _forbiddenHeaders = [
 ];
 
 bool isHeaderForbidden(String header) {
-  return _forbiddenHeaders.any((element) => element.matchAsPrefix(header) != null);
+  return _forbiddenHeaders
+      .any((element) => element.matchAsPrefix(header) != null);
 }

--- a/pubnub/lib/src/networking/utils.dart
+++ b/pubnub/lib/src/networking/utils.dart
@@ -1,0 +1,28 @@
+const _forbiddenHeaders = [
+  'Accept-Charset',
+  'Accept-Encoding',
+  'Access-Control-Request-Headers',
+  'Access-Control-Request-Method',
+  'Connection',
+  'Content-Length',
+  'Cookie',
+  'Date',
+  'DNT',
+  'Expect',
+  'Feature-Policy',
+  'Host',
+  'Keep-Alive',
+  'Origin',
+  'Proxy-',
+  'Sec-',
+  'Referer',
+  'TE',
+  'Trailer',
+  'Transfer-Encoding',
+  'Upgrade',
+  'Via',
+];
+
+bool isHeaderForbidden(String header) {
+  return _forbiddenHeaders.any((element) => element.matchAsPrefix(header) != null);
+}

--- a/pubnub/pubspec.yaml
+++ b/pubnub/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pubnub
 description: PubNub SDK v5 for Dart lang (with Flutter support) that allows you to create real-time applications
-version: 4.1.1
+version: 4.1.2
 homepage: https://www.pubnub.com/docs
 
 environment:

--- a/pubnub/test/unit/dx/fixtures/files.dart
+++ b/pubnub/test/unit/dx/fixtures/files.dart
@@ -1,4 +1,4 @@
 part of '../file_test.dart';
 
 final _getFileUrl =
-    'https://ps.pndsn.com/v1/files/test/channels/channel/files/fileId/fileName?pnsdk=PubNub-Dart%2F${PubNub.version}';
+    'https://ps.pndsn.com/v1/files/test/channels/channel/files/fileId/fileName?pnsdk=PubNub-Dart%2F${PubNub.version}&uuid=test';

--- a/pubnub/test/unit/net/utils.dart
+++ b/pubnub/test/unit/net/utils.dart
@@ -1,0 +1,22 @@
+import 'package:test/test.dart';
+
+import 'package:pubnub/src/networking/utils.dart';
+
+void main() {
+  group('Networking utils', () {
+    test('isHeaderForbidden should return true for Content-Length header', () {
+      expect(isHeaderForbidden('Content-Length'), equals(true));
+    });
+
+    test('isHeaderForbidden should return true for any Sec- or Proxy- header', () {
+      expect(isHeaderForbidden('Sec-Test-1'), equals(true));
+      expect(isHeaderForbidden('Sec-Random-2'), equals(true));
+      expect(isHeaderForbidden('Proxy-Whatever'), equals(true));
+    });
+
+    test('isHeaderForbidden should return false for any other header not specified', () {
+      expect(isHeaderForbidden('X-Custom-Header'), equals(false));
+      expect(isHeaderForbidden('Content-Type'), equals(false));
+    });
+  });
+}


### PR DESCRIPTION
fix: prevent the SDK from adding forbidden headers to requests in browser environments

Adds a fix that prevents the SDK from adding forbidden headers in browser environments.

fix: include UUID in download file url generation

Fixes getFileUrl method by adding uuid in query parameters.