### PR TITLE
fix: `fetchMessages` with includeUUID failure.

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,5 +1,12 @@
 ---
 changelog:
+  - date: 2022-04-21
+    version: v4.1.3
+    changes:
+      - type: bug
+        text: "Fixes issue of `fetchMessages` with false includeUUID response parse error."
+      - type: bug
+        text: "Fixes issue of publish file message not triggered on browser."
   - date: 2022-04-06
     version: v4.1.2
     changes:
@@ -387,7 +394,7 @@ supported-platforms:
     platforms:
       - "Dart SDK >=2.6.0 <3.0.0"
     version: "PubNub Dart SDK"
-version: "4.1.2"
+version: "4.1.3"
 sdks:
   -
     full-name: PubNub Dart SDK

--- a/pubnub/CHANGELOG.md
+++ b/pubnub/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v4.1.3
+April 21 2022
+
+#### Fixed
+- Fixes issue of `fetchMessages` with false includeUUID response parse error. Fixed the following issues reported by [@linsdev](https://github.com/linsdev): [#89](https://github.com/pubnub/dart/issues/89).
+- Fixes issue of publish file message not triggered on browser.
+
 ## v4.1.2
 April 06 2022
 

--- a/pubnub/README.md
+++ b/pubnub/README.md
@@ -14,7 +14,7 @@ To add the package to your Dart or Flutter project, add `pubnub` as a dependency
 
 ```yaml
 dependencies:
-  pubnub: ^4.1.2
+  pubnub: ^4.1.3
 ```
 
 After adding the dependency to `pubspec.yaml`, run the `pub get` command in the root directory of your project (the same that the `pubspec.yaml` is in).

--- a/pubnub/lib/src/core/core.dart
+++ b/pubnub/lib/src/core/core.dart
@@ -21,7 +21,7 @@ class Core {
   /// Internal module responsible for supervising.
   SupervisorModule supervisor = SupervisorModule();
 
-  static String version = '4.1.2';
+  static String version = '4.1.3';
 
   Core(
       {Keyset? defaultKeyset,

--- a/pubnub/lib/src/dx/_endpoints/history.dart
+++ b/pubnub/lib/src/dx/_endpoints/history.dart
@@ -136,8 +136,9 @@ class BatchHistoryResultEntry {
   /// Original timetoken of the message.
   Timetoken timetoken;
 
-  /// UUID of the sender.
-  String uuid;
+  /// If `includeUUID` was true, this will contain UUID of the sender.
+  /// Otherwise, it will be `null`.
+  String? uuid;
 
   /// Type of the message.
   MessageType messageType;

--- a/pubnub/pubspec.yaml
+++ b/pubnub/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pubnub
 description: PubNub SDK v5 for Dart lang (with Flutter support) that allows you to create real-time applications
-version: 4.1.2
+version: 4.1.3
 homepage: https://www.pubnub.com/docs
 
 environment:


### PR DESCRIPTION
fix: `fetchMessages` with false includeUUID failure.

Fixes issue of `fetchMessages` with false includeUUID response parse error.

Closes #89

fix: publish file message not triggered on browser issue.

Fixes issue of publish file message not triggered on browser.