### PR TITLE
Fix docs build command

### DIFF
--- a/.github/workflows/release/pre-github-pages-publish.sh
+++ b/.github/workflows/release/pre-github-pages-publish.sh
@@ -2,4 +2,4 @@
 set -e
 
 # Command will be called with `cwd` set to current product path.
-dartdoc --quiet --no-include-source --use-categories
+dart doc


### PR DESCRIPTION
build(docs): fix docs build command

Fix command which is used to build documentation for GitHub Pages.