### PR TITLE
Take account of maximumDelay in LinearRetryPolicy

### DIFF
--- a/pubnub/lib/src/core/policies/retry_policy.dart
+++ b/pubnub/lib/src/core/policies/retry_policy.dart
@@ -41,7 +41,8 @@ class LinearRetryPolicy extends RetryPolicy {
   @override
   Duration getDelay(Fiber fiber) {
     return Duration(
-        milliseconds: (fiber.tries * backoff) + Random().nextInt(1000));
+        milliseconds: min(maximumDelay,
+            (fiber.tries * backoff) + Random().nextInt(1000)));
   }
 }
 


### PR DESCRIPTION
It appears that the linear retry policy is not being limited by the maximumDelay. This fixes it, following how exponential retry handles the maximum delay.