### PR TITLE
fix: omit optional parameters for AppContext APIs

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,5 +1,10 @@
 ---
 changelog:
+  - date: 2025-01-20
+    version: v5.1.1
+    changes:
+      - type: bug
+        text: "Fixes issue of getting error for setUUIDMetadata call without `custom` field."
   - date: 2024-12-18
     version: v5.1.0
     changes:
@@ -466,7 +471,7 @@ supported-platforms:
     platforms:
       - "Dart SDK >=2.6.0 <3.0.0"
     version: "PubNub Dart SDK"
-version: "5.1.0"
+version: "5.1.1"
 sdks:
   -
     full-name: PubNub Dart SDK

--- a/pubnub/CHANGELOG.md
+++ b/pubnub/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v5.1.1
+January 20 2025
+
+#### Fixed
+- Fixes issue of getting error for setUUIDMetadata call without `custom` field.
+
 ## v5.1.0
 December 18 2024
 

--- a/pubnub/README.md
+++ b/pubnub/README.md
@@ -14,7 +14,7 @@ To add the package to your Dart or Flutter project, add `pubnub` as a dependency
 
 ```yaml
 dependencies:
-  pubnub: ^5.1.0
+  pubnub: ^5.1.1
 ```
 
 After adding the dependency to `pubspec.yaml`, run the `dart pub get` command in the root directory of your project (the same that the `pubspec.yaml` is in).

--- a/pubnub/lib/src/core/core.dart
+++ b/pubnub/lib/src/core/core.dart
@@ -21,7 +21,7 @@ class Core {
   /// Internal module responsible for supervising.
   SupervisorModule supervisor = SupervisorModule();
 
-  static String version = '5.1.0';
+  static String version = '5.1.1';
 
   Core(
       {Keyset? defaultKeyset,

--- a/pubnub/lib/src/dx/objects/schema.dart
+++ b/pubnub/lib/src/dx/objects/schema.dart
@@ -20,13 +20,13 @@ class UuidMetadataInput {
       this.type});
 
   Map<String, dynamic> toJson() => <String, dynamic>{
-        'name': name,
-        'email': email,
-        'custom': custom,
-        'externalId': externalId,
-        'profileUrl': profileUrl,
-        'status': status,
-        'type': type,
+        if (name != null) 'name': name,
+        if (email != null) 'email': email,
+        if (custom != null) 'custom': custom,
+        if (externalId != null) 'externalId': externalId,
+        if (profileUrl != null) 'profileUrl': profileUrl,
+        if (status != null) 'status': status,
+        if (type != null) 'type': type,
       };
 }
 
@@ -44,11 +44,11 @@ class ChannelMetadataInput {
       {this.name, this.description, this.custom, this.status, this.type});
 
   Map<String, dynamic> toJson() => <String, dynamic>{
-        'name': name,
-        'description': description,
-        'custom': custom,
-        'status': status,
-        'type': type,
+        if (name != null) 'name': name,
+        if (description != null) 'description': description,
+        if (custom != null) 'custom': custom,
+        if (status != null) 'status': status,
+        if (type != null) 'type': type,
       };
 }
 
@@ -65,9 +65,9 @@ class ChannelMemberMetadataInput {
 
   Map<String, dynamic> toJson() => <String, dynamic>{
         'uuid': {'id': uuid},
-        'custom': custom,
-        'status': status,
-        'type': type,
+        if (custom != null) 'custom': custom,
+        if (status != null) 'status': status,
+        if (type != null) 'type': type,
       };
 }
 
@@ -85,9 +85,9 @@ class MembershipMetadataInput {
 
   Map<String, dynamic> toJson() => <String, dynamic>{
         'channel': {'id': channelId},
-        'custom': custom,
-        'status': status,
-        'type': type,
+        if (custom != null) 'custom': custom,
+        if (status != null) 'status': status,
+        if (type != null) 'type': type,
       };
 }
 

--- a/pubnub/pubspec.yaml
+++ b/pubnub/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pubnub
 description: PubNub SDK v5 for Dart lang (with Flutter support) that allows you to create real-time applications
-version: 5.1.0
+version: 5.1.1
 homepage: https://www.pubnub.com/docs/sdks/dart
 
 environment:


### PR DESCRIPTION
fix: Omit optional parameters for AppContext entity fields.

Fixes issue of getting error for setUUIDMetadata call without `custom` field