### PR TITLE
eTag for set UUID and Channel metadata

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -95,7 +95,7 @@ jobs:
           export FEATURES_PATH=../sdk-specifications/features
           dart pub run acceptance_tests
       - name: Expose acceptance tests reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: acceptance-test-reports
           path: acceptance_tests/report.xml

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,5 +1,10 @@
 ---
 changelog:
+  - date: 2025-03-12
+    version: v5.2.0
+    changes:
+      - type: feature
+        text: "Added Support of `eTag` for AppContext `setUUIDMetadata` and `setChannelMetadata` APIs."
   - date: 2025-01-20
     version: v5.1.1
     changes:
@@ -471,7 +476,7 @@ supported-platforms:
     platforms:
       - "Dart SDK >=2.6.0 <3.0.0"
     version: "PubNub Dart SDK"
-version: "5.1.1"
+version: "5.2.0"
 sdks:
   -
     full-name: PubNub Dart SDK

--- a/pubnub/CHANGELOG.md
+++ b/pubnub/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v5.2.0
+March 12 2025
+
+#### Added
+- Added Support of `eTag` for AppContext `setUUIDMetadata` and `setChannelMetadata` APIs.
+
 ## v5.1.1
 January 20 2025
 

--- a/pubnub/README.md
+++ b/pubnub/README.md
@@ -14,7 +14,7 @@ To add the package to your Dart or Flutter project, add `pubnub` as a dependency
 
 ```yaml
 dependencies:
-  pubnub: ^5.1.1
+  pubnub: ^5.2.0
 ```
 
 After adding the dependency to `pubspec.yaml`, run the `dart pub get` command in the root directory of your project (the same that the `pubspec.yaml` is in).

--- a/pubnub/lib/src/core/core.dart
+++ b/pubnub/lib/src/core/core.dart
@@ -21,7 +21,7 @@ class Core {
   /// Internal module responsible for supervising.
   SupervisorModule supervisor = SupervisorModule();
 
-  static String version = '5.1.1';
+  static String version = '5.2.0';
 
   Core(
       {Keyset? defaultKeyset,

--- a/pubnub/lib/src/dx/_endpoints/objects/channel_metadata.dart
+++ b/pubnub/lib/src/dx/_endpoints/objects/channel_metadata.dart
@@ -148,9 +148,10 @@ class SetChannelMetadataParams extends Parameters {
   Set<String>? include;
 
   String channelMetadata;
+  String? ifMatchesEtag;
 
   SetChannelMetadataParams(this.keyset, this.channelId, this.channelMetadata,
-      {this.include});
+      {this.include, this.ifMatchesEtag});
 
   @override
   Request toRequest() {
@@ -172,7 +173,9 @@ class SetChannelMetadataParams extends Parameters {
             pathSegments: pathSegments,
             queryParameters:
                 queryParameters.isNotEmpty ? queryParameters : null),
-        body: channelMetadata);
+        body: channelMetadata,
+        headers:
+            ifMatchesEtag != null ? {'If-Match': ifMatchesEtag ?? ''} : {});
   }
 }
 

--- a/pubnub/lib/src/dx/_endpoints/objects/uuid_metadata.dart
+++ b/pubnub/lib/src/dx/_endpoints/objects/uuid_metadata.dart
@@ -154,9 +154,10 @@ class SetUuidMetadataParams extends Parameters {
   String? uuid;
   Set<String>? include;
   String uuidMetadata;
+  String? ifMatchesEtag;
 
   SetUuidMetadataParams(this.keyset, this.uuidMetadata,
-      {this.include, this.uuid});
+      {this.include, this.uuid, this.ifMatchesEtag});
   @override
   Request toRequest() {
     var pathSegments = [
@@ -172,7 +173,9 @@ class SetUuidMetadataParams extends Parameters {
     };
     return Request.patch(
         uri: Uri(pathSegments: pathSegments, queryParameters: queryParameters),
-        body: uuidMetadata);
+        body: uuidMetadata,
+        headers:
+            ifMatchesEtag != null ? {'If-Match': ifMatchesEtag ?? ''} : {});
   }
 }
 

--- a/pubnub/lib/src/dx/objects/objects.dart
+++ b/pubnub/lib/src/dx/objects/objects.dart
@@ -159,12 +159,18 @@ class ObjectsDx {
   /// * In case of null `uuid` it sets metadata for PubNub instance's `uuid`
   /// * If no `uuid` is set in PubNub instance default keyset, `keyset` does not hold uuid
   /// and `uuid` not provided in method argument then it throws InvariantException
+  ///
+  /// You can provide [ifMatchesEtag] value to prevent concurrent modification of the same User object
+  /// this allows clients to (optionally) request that their updates only be performed if the object hasn't been modified since it was read.
+  /// If the request is sent with an old eTag value that doesn't match the User object's current eTag value, the request will fail with a 412 (Precondition failed) error.
+  ///
   Future<SetUuidMetadataResult> setUUIDMetadata(
       UuidMetadataInput uuidMetadataInput,
       {String? uuid,
       bool? includeCustomFields,
       bool includeStatus = true,
       bool includeType = true,
+      String? ifMatchesEtag,
       Keyset? keyset,
       String? using}) async {
     keyset ??= _core.keysets[using];
@@ -182,8 +188,8 @@ class ObjectsDx {
     }
 
     var payload = await _core.parser.encode(uuidMetadataInput);
-    var params =
-        SetUuidMetadataParams(keyset, payload, uuid: uuid, include: include);
+    var params = SetUuidMetadataParams(keyset, payload,
+        uuid: uuid, include: include, ifMatchesEtag: ifMatchesEtag);
 
     return defaultFlow<SetUuidMetadataParams, SetUuidMetadataResult>(
         keyset: keyset,
@@ -344,11 +350,17 @@ class ObjectsDx {
   ///
   /// To include `custom` property fields in response, set [includeCustomFields] to `true`
   /// Omit this parameter if you don't want to retrieve additional metadata.
+  ///
+  /// You can provide [ifMatchesEtag] value to prevent concurrent modification of the same channel object
+  /// this allows clients to (optionally) request that their updates only be performed if the object hasn't been modified since it was read.
+  /// If the request is sent with an old eTag value that doesn't match the Channel object's current eTag value, the request will fail with a 412 (Precondition failed) error.
+  ///
   Future<SetChannelMetadataResult> setChannelMetadata(
       String channelId, ChannelMetadataInput channelMetadataInput,
       {bool? includeCustomFields,
       bool includeStatus = true,
       bool includeType = true,
+      String? ifMatchesEtag,
       Keyset? keyset,
       String? using}) async {
     keyset ??= _core.keysets[using];
@@ -369,8 +381,8 @@ class ObjectsDx {
       include.add('type');
     }
 
-    var params =
-        SetChannelMetadataParams(keyset, channelId, payload, include: include);
+    var params = SetChannelMetadataParams(keyset, channelId, payload,
+        include: include, ifMatchesEtag: ifMatchesEtag);
 
     return defaultFlow<SetChannelMetadataParams, SetChannelMetadataResult>(
         keyset: keyset,

--- a/pubnub/lib/src/networking/request_handler/io.dart
+++ b/pubnub/lib/src/networking/request_handler/io.dart
@@ -72,6 +72,9 @@ class RequestHandler extends IRequestHandler {
       } else {
         if (data.body != null) {
           headers['Content-Type'] = 'application/json';
+          if (data.headers != null && data.headers!.isNotEmpty) {
+            data.headers!.forEach((k, v) => headers[k] = v);
+          }
           body = utf8.encode(data.body.toString());
         }
       }

--- a/pubnub/pubspec.yaml
+++ b/pubnub/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pubnub
 description: PubNub SDK v5 for Dart lang (with Flutter support) that allows you to create real-time applications
-version: 5.1.1
+version: 5.2.0
 homepage: https://www.pubnub.com/docs/sdks/dart
 
 environment:


### PR DESCRIPTION
feat: Support of `eTag` for AppContext `setUUIDMetadata` and `setChannelMetadata` APIs.

Added Support of `eTag` for AppContext `setUUIDMetadata` and `setChannelMetadata` APIs.