### PR TITLE
added deprecation warnings for legacy cryptor, cipherKey provided in …

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,5 +1,12 @@
 ---
 changelog:
+  - date: 2026-07-20
+    version: v8.0.1
+    changes:
+      - type: bug
+        text: "Added deprecation warning for legacy cryptor configuration, cipherKey initialisation at Keyset level."
+      - type: bug
+        text: "Refactored exception handling in cryptors without revealing extensive details of failure."
   - date: 2026-07-06
     version: v8.0.0
     changes:
@@ -536,7 +543,7 @@ supported-platforms:
     platforms:
       - "Dart SDK >=2.6.0 <3.0.0"
     version: "PubNub Dart SDK"
-version: "8.0.0"
+version: "8.0.1"
 sdks:
   -
     full-name: PubNub Dart SDK

--- a/pubnub/CHANGELOG.md
+++ b/pubnub/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v8.0.1
+July 20 2026
+
+#### Fixed
+- Added deprecation warning for legacy cryptor configuration, cipherKey initialisation at Keyset level.
+- Refactored exception handling in cryptors without revealing extensive details of failure.
+
 ## v8.0.0
 July 06 2026
 

--- a/pubnub/README.md
+++ b/pubnub/README.md
@@ -14,7 +14,7 @@ To add the package to your Dart or Flutter project, add `pubnub` as a dependency
 
 ```yaml
 dependencies:
-  pubnub: ^8.0.0
+  pubnub: ^8.0.1
 ```
 
 After adding the dependency to `pubspec.yaml`, run the `dart pub get` command in the root directory of your project (the same that the `pubspec.yaml` is in).

--- a/pubnub/lib/src/core/core.dart
+++ b/pubnub/lib/src/core/core.dart
@@ -21,7 +21,7 @@ class Core {
   /// Internal module responsible for supervising.
   SupervisorModule supervisor = SupervisorModule();
 
-  static String version = '8.0.0';
+  static String version = '8.0.1';
 
   static String instanceId =
       '${(DateTime.now().millisecondsSinceEpoch % 100000)}'.padLeft(5);

--- a/pubnub/lib/src/core/keyset/keyset.dart
+++ b/pubnub/lib/src/core/keyset/keyset.dart
@@ -22,6 +22,10 @@ class Keyset {
   final String? secretKey;
 
   /// Used for message encryption.
+  ///
+  /// Prefer configuring encryption on the `PubNub` instance with an AES-CBC
+  /// cryptor instead of setting a `cipherKey` here (which uses the legacy
+  /// cryptor). See [Keyset.new] for details.
   final CipherKey? cipherKey;
 
   /// If PAM is enabled, authentication key is required to access channels.
@@ -37,7 +41,13 @@ class Keyset {
     this.publishKey,
     this.secretKey,
     this.authKey,
-    @Deprecated('Use `cipherKey` at CryptoModule') this.cipherKey,
+    @Deprecated(
+        'Providing a cipherKey on Keyset uses the legacy cryptor. Configure '
+        'encryption on the PubNub instance with an AES-CBC cryptor instead, '
+        'e.g. PubNub(crypto: CryptoModule.aesCbcCryptoModule('
+        'CipherKey.fromUtf8("your-cipher-key")), defaultKeyset: ...). '
+        'This parameter will be removed in a future release.')
+    this.cipherKey,
   })  : assert((uuid == null) ^ (userId == null)),
         uuid = userId != null ? UUID(userId.value) : uuid!;
 
@@ -52,7 +62,10 @@ class Keyset {
       'Cipher Key: ${cipherKey != null ? 'provided' : 'not provided'}'
     ];
     if (settings.isNotEmpty) {
-      parts.add('Settings: $settings');
+      // `settings` can hold sensitive values (e.g. the PAM access token stored
+      // under the `#token` key by the PAM extension), so never print raw
+      // values here. Emit only the setting names.
+      parts.add('Settings: ${settings.keys.toList()}');
     }
     return '\n\t    ${parts.join('\n\t    ')}';
   }

--- a/pubnub/lib/src/crypto/aesCbcCryptor.dart
+++ b/pubnub/lib/src/crypto/aesCbcCryptor.dart
@@ -4,6 +4,15 @@ import 'dart:typed_data' show Uint8List;
 
 import 'package:pubnub/core.dart';
 
+final _logger = injectLogger('pubnub.crypto.aescbc');
+
+/// Opaque message thrown for all decryption failures.
+///
+/// The underlying exception is intentionally excluded from the thrown message
+/// to avoid leaking details that could aid a decryption/padding oracle attack.
+/// The real cause is logged internally via [_logger] instead.
+const String _decryptionErrorMessage = 'decryption error';
+
 /// AesCbcCryptor is new and enhanced cryptor to encrypt/decrypt
 /// PubNub messages.
 /// It's always preferred to use this cryptor instead old cryptor.
@@ -19,9 +28,14 @@ class AesCbcCryptor implements ICryptor {
     var encrypter = crypto.Encrypter(
       crypto.AES(_getKey(), mode: crypto.AESMode.cbc),
     );
-    return encrypter.decryptBytes(
-        crypto.Encrypted(Uint8List.fromList(encryptedData.data.toList())),
-        iv: crypto.IV(Uint8List.fromList(encryptedData.metadata.toList())));
+    try {
+      return encrypter.decryptBytes(
+          crypto.Encrypted(Uint8List.fromList(encryptedData.data.toList())),
+          iv: crypto.IV(Uint8List.fromList(encryptedData.metadata.toList())));
+    } catch (e) {
+      _logger.warning('AES-CBC decryption failed: $e');
+      throw CryptoException(_decryptionErrorMessage);
+    }
   }
 
   @override

--- a/pubnub/lib/src/crypto/crypto.dart
+++ b/pubnub/lib/src/crypto/crypto.dart
@@ -21,9 +21,19 @@ class CryptoModule implements ICryptoModule {
         LegacyCryptoModule(defaultConfiguration: defaultConfiguration);
   }
 
+  /// Creates a [CryptoModule] that encrypts with the legacy cryptor.
+  ///
+  /// New content is encrypted using the deprecated [LegacyCryptor]. Prefer
+  /// [CryptoModule.aesCbcCryptoModule], which encrypts with [AesCbcCryptor]
+  /// while still decrypting legacy content.
+  @Deprecated(
+      'Use CryptoModule.aesCbcCryptoModule for new applications. This factory '
+      'encrypts with the legacy cryptor and is retained only for '
+      'backward compatibility.')
   factory CryptoModule.legacyCryptoModule(CipherKey cipherKey,
       {defaultCryptoConfiguration = const CryptoConfiguration()}) {
     return CryptoModule(
+        // ignore: deprecated_member_use_from_same_package
         defaultCryptor: LegacyCryptor(cipherKey,
             cryptoConfiguration: defaultCryptoConfiguration),
         cryptors: <ICryptor>[AesCbcCryptor(cipherKey)]);
@@ -34,6 +44,7 @@ class CryptoModule implements ICryptoModule {
     return CryptoModule(
         defaultCryptor: AesCbcCryptor(cipherKey),
         cryptors: <ICryptor>[
+          // ignore: deprecated_member_use_from_same_package
           LegacyCryptor(cipherKey,
               cryptoConfiguration: defaultCryptoConfiguration),
         ]);

--- a/pubnub/lib/src/crypto/cryptoConfiguration.dart
+++ b/pubnub/lib/src/crypto/cryptoConfiguration.dart
@@ -9,10 +9,21 @@ class CryptoConfiguration {
   final bool encryptKey;
 
   /// Whether a random IV should be used.
+  ///
+  /// A random initialization vector is required for secure encryption. Setting
+  /// this to `false` selects a hard-coded static IV, which is insecure and
+  /// exists only to decrypt historical content. Prefer [AesCbcCryptor], which
+  /// always uses a random IV.
+  @Deprecated(
+      'A static initialization vector is insecure. Keep this enabled (the '
+      'default) or migrate to AesCbcCryptor. The static-IV option is retained '
+      'only for backward-compatible decryption and will be removed in a future '
+      'release.')
   final bool useRandomInitializationVector;
 
   const CryptoConfiguration(
       {this.encryptionMode = EncryptionMode.CBC,
       this.encryptKey = true,
+      // ignore: deprecated_member_use_from_same_package
       this.useRandomInitializationVector = true});
 }

--- a/pubnub/lib/src/crypto/legacyCryptor.dart
+++ b/pubnub/lib/src/crypto/legacyCryptor.dart
@@ -9,8 +9,28 @@ import 'cryptoConfiguration.dart';
 import 'encryption_mode.dart';
 import 'crypto.dart';
 
+final _logger = injectLogger('pubnub.crypto.legacy');
+
+/// Opaque message thrown for all decryption failures.
+///
+/// The underlying exception is intentionally excluded from the thrown message
+/// to avoid leaking details that could aid a decryption/padding oracle attack.
+/// The real cause is logged internally via [_logger] instead.
+const String _decryptionErrorMessage = 'decryption error';
+
+/// Opaque message thrown for all encryption failures.
+const String _encryptionErrorMessage = 'encryption error';
+
 /// Legacy cryptor exists so that SDK will be able to decrypt old contents
-/// Which encrypted in past
+/// which were encrypted in the past.
+///
+/// It uses AES-CBC with a key derived by SHA-256 and, by default, a random IV.
+/// For new applications prefer [AesCbcCryptor], which is the enhanced,
+/// recommended cryptor.
+@Deprecated(
+    'Use AesCbcCryptor for new applications. LegacyCryptor is retained only '
+    'to decrypt content encrypted by older SDK versions and will be removed '
+    'in a future release.')
 class LegacyCryptor implements ICryptor {
   final CryptoConfiguration cryptoConfiguration;
   final CipherKey cipherKey;
@@ -91,6 +111,7 @@ class LegacyCryptoModule implements ICryptoModule {
     var encrypter = crypto.Encrypter(
         crypto.AES(_getKey(key, config), mode: config.encryptionMode.value()));
     try {
+      // ignore: deprecated_member_use_from_same_package
       if (config.useRandomInitializationVector) {
         return encrypter.decryptBytes(
             crypto.Encrypted(Uint8List.fromList(input.sublist(16))),
@@ -101,7 +122,8 @@ class LegacyCryptoModule implements ICryptoModule {
             .decryptBytes(crypto.Encrypted(Uint8List.fromList(input)), iv: iv);
       }
     } catch (e) {
-      throw CryptoException('Error while decrypting message:\n$e');
+      _logger.warning('Legacy message decryption failed: $e');
+      throw CryptoException(_decryptionErrorMessage);
     }
   }
 
@@ -116,6 +138,7 @@ class LegacyCryptoModule implements ICryptoModule {
     var encrypter = crypto.Encrypter(
         crypto.AES(_getKey(key, config), mode: config.encryptionMode.value()));
     try {
+      // ignore: deprecated_member_use_from_same_package
       if (config.useRandomInitializationVector) {
         var iv = crypto.IV.fromSecureRandom(16);
         var encrypted = [];
@@ -129,7 +152,8 @@ class LegacyCryptoModule implements ICryptoModule {
         return encrypter.encryptBytes(input, iv: iv).bytes;
       }
     } catch (e) {
-      throw CryptoException('Error while encrypting message:\n$e');
+      _logger.warning('Legacy message encryption failed: $e');
+      throw CryptoException(_encryptionErrorMessage);
     }
   }
 
@@ -147,7 +171,8 @@ class LegacyCryptoModule implements ICryptoModule {
           crypto.Encrypted(Uint8List.fromList(input.sublist(16))),
           iv: crypto.IV.fromBase64(base64.encode(input.sublist(0, 16))));
     } catch (e) {
-      throw CryptoException('Error while decrypting file data: \n$e}');
+      _logger.warning('Legacy file data decryption failed: $e');
+      throw CryptoException(_decryptionErrorMessage);
     }
   }
 
@@ -166,7 +191,8 @@ class LegacyCryptoModule implements ICryptoModule {
       var encrypted = encrypter.encryptBytes(input, iv: iv).bytes;
       return [...iv.bytes, ...encrypted];
     } catch (e) {
-      throw CryptoException('Error while encrypting file data:\n$e');
+      _logger.warning('Legacy file data encryption failed: $e');
+      throw CryptoException(_encryptionErrorMessage);
     }
   }
 

--- a/pubnub/pubspec.yaml
+++ b/pubnub/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pubnub
 description: PubNub SDK for Dart lang (with Flutter support) that allows you to create real-time applications
-version: 8.0.0
+version: 8.0.1
 homepage: https://www.pubnub.com/docs/sdks/dart
 
 environment:


### PR DESCRIPTION
fix: added deprecation warning for legacy cryptor configuration, cipherKey initialisation at Keyset level.

added deprecation warning for legacy cryptor configuration, cipherKey initialisation at Keyset level.

fix: exception handling in cryptors without revealing extensive details of failure.

refactored exception handling in cryptors without revealing extensive details of failure.